### PR TITLE
Handle ImmutableArray<T> as a sequence in equality generation and add tests

### DIFF
--- a/src/Valuify.Tests/Model/PropertyTests/WhenEqualityIsChecked.cs
+++ b/src/Valuify.Tests/Model/PropertyTests/WhenEqualityIsChecked.cs
@@ -3,6 +3,35 @@
 public abstract class WhenEqualityIsChecked
 {
     [Fact]
+    public void GivenADifferentIsImmutableArrayThenTheyAreNotDeemedEqual()
+    {
+        // Arrange
+        var instance1 = new Property
+        {
+            IsIgnored = true,
+            IsImmutableArray = true,
+            IsSequence = true,
+            Name = "PropertyName",
+            Type = "string[]",
+        };
+
+        var instance2 = new Property
+        {
+            IsIgnored = true,
+            IsImmutableArray = false,
+            IsSequence = true,
+            Name = "PropertyName",
+            Type = "string[]",
+        };
+
+        // Act
+        bool areEqual = AreEqual(instance1, instance2);
+
+        // Assert
+        areEqual.ShouldBeFalse();
+    }
+
+    [Fact]
     public void GivenADifferentIsIgnoredThenTheyAreNotDeemedEqual()
     {
         // Arrange

--- a/src/Valuify.Tests/Model/PropertyTests/WhenInequalityIsChecked.cs
+++ b/src/Valuify.Tests/Model/PropertyTests/WhenInequalityIsChecked.cs
@@ -3,6 +3,35 @@
 public abstract class WhenInequalityIsChecked
 {
     [Fact]
+    public void GivenADifferentIsImmutableArrayThenTheyAreNotDeemedEqual()
+    {
+        // Arrange
+        var instance1 = new Property
+        {
+            IsIgnored = true,
+            IsImmutableArray = true,
+            IsSequence = true,
+            Name = "PropertyName",
+            Type = "string[]",
+        };
+
+        var instance2 = new Property
+        {
+            IsIgnored = true,
+            IsImmutableArray = false,
+            IsSequence = true,
+            Name = "PropertyName",
+            Type = "string[]",
+        };
+
+        // Act
+        bool areNotEqual = AreNotEqual(instance1, instance2);
+
+        // Assert
+        areNotEqual.ShouldBeTrue();
+    }
+
+    [Fact]
     public void GivenADifferentIsIgnoredThenTheyAreNotDeemedEqual()
     {
         // Arrange

--- a/src/Valuify.Tests/Snippets/Declarations/ImmutableArrayProperty.Declarations.cs
+++ b/src/Valuify.Tests/Snippets/Declarations/ImmutableArrayProperty.Declarations.cs
@@ -1,0 +1,31 @@
+namespace Valuify.Snippets.Declarations;
+
+using Microsoft.CodeAnalysis.CSharp;
+
+internal static partial class ImmutableArrayProperty
+{
+    public static class Declarations
+    {
+        public static readonly Content CSharp9Body = new(
+            """
+                {
+                    public ImmutableArray<int> Values { get; init; }
+                }
+            """,
+            LanguageVersion.CSharp9);
+
+        public static readonly Content Main = new(
+            """
+            namespace Valuify.Classes.Testing
+            {
+                using System;
+                using System.Collections.Immutable;
+
+                [Valuify]
+                public sealed partial class ImmutableArrayProperty
+            __BODY__
+            }
+            """,
+            LanguageVersion.CSharp2);
+    }
+}

--- a/src/Valuify.Tests/Snippets/Declarations/ImmutableArrayProperty.Expected.cs
+++ b/src/Valuify.Tests/Snippets/Declarations/ImmutableArrayProperty.Expected.cs
@@ -1,0 +1,213 @@
+namespace Valuify.Snippets.Declarations;
+
+internal static partial class ImmutableArrayProperty
+{
+    public static class Expected
+    {
+        public static readonly Generated Equality = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Immutable;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class ImmutableArrayProperty
+                    {
+                        public static bool operator ==(ImmutableArrayProperty left, ImmutableArrayProperty right)
+                        {
+                            if (ReferenceEquals(left, right))
+                            {
+                                return true;
+                            }
+                
+                            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+                            {
+                                return false;
+                            }
+                
+                            return left.Equals(right);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasEqualityOperator,
+            "Valuify.Classes.Testing.ImmutableArrayProperty.Equality");
+
+        public static new readonly Generated Equals = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Immutable;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class ImmutableArrayProperty
+                    {
+                        public override bool Equals(object other)
+                        {
+                            return Equals(other as ImmutableArrayProperty);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasEqualsOverride,
+            "Valuify.Classes.Testing.ImmutableArrayProperty.Equals");
+
+        public static readonly Generated EquatableContract = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Immutable;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class ImmutableArrayProperty
+                        : IEquatable<ImmutableArrayProperty>
+                    {
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.IsEquatable,
+            "Valuify.Classes.Testing.ImmutableArrayProperty.IEquatable");
+
+        public static readonly Generated EquatableImplementation = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Immutable;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class ImmutableArrayProperty
+                    {
+                        public bool Equals(ImmutableArrayProperty other)
+                        {
+                            if (ReferenceEquals(this, other))
+                            {
+                                return true;
+                            }
+                
+                            if (ReferenceEquals(other, null))
+                            {
+                                return false;
+                            }
+                
+                            return global::Valuify.Internal.SequenceEqualityComparer.Default.Equals(Values, other.Values);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasEquatable,
+            "Valuify.Classes.Testing.ImmutableArrayProperty.IEquatable.Equals");
+
+        public static new readonly Generated GetHashCode = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Immutable;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+        
+                    partial class ImmutableArrayProperty
+                    {
+                        public override int GetHashCode()
+                        {
+                            return global::Valuify.Internal.HashCode.Combine(Values);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasGetHashCodeOverride,
+            "Valuify.Classes.Testing.ImmutableArrayProperty.GetHashCode");
+
+        public static readonly Generated Inequality = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Immutable;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class ImmutableArrayProperty
+                    {
+                        public static bool operator !=(ImmutableArrayProperty left, ImmutableArrayProperty right)
+                        {
+                            return !(left == right);
+                        }
+                    }
+        
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasInequalityOperator,
+            "Valuify.Classes.Testing.ImmutableArrayProperty.Inequality");
+
+        public static new readonly Generated ToString = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Immutable;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class ImmutableArrayProperty
+                    {
+                        public override string ToString()
+                        {
+                            return string.Format("ImmutableArrayProperty {{ Values = {0} }}", Values);
+                        }
+                    }
+        
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasToStringOverride,
+            "Valuify.Classes.Testing.ImmutableArrayProperty.ToString");
+    }
+}

--- a/src/Valuify.Tests/Snippets/Declarations/ImmutableArrayProperty.cs
+++ b/src/Valuify.Tests/Snippets/Declarations/ImmutableArrayProperty.cs
@@ -1,0 +1,29 @@
+namespace Valuify.Snippets.Declarations;
+
+internal static partial class ImmutableArrayProperty
+{
+    public static readonly Snippets Declaration = new(
+        [
+            Declarations.CSharp9Body,
+        ],
+        Declarations.Main,
+        [
+            Expected.Equality,
+            Expected.Equals,
+            Expected.EquatableContract,
+            Expected.EquatableImplementation,
+            Expected.GetHashCode,
+            Expected.Inequality,
+            Expected.ToString,
+        ],
+        [
+            new(Expected.Equality.Content, Extensions.HasEqualityOperator),
+            new(Expected.Equals.Content, Extensions.HasEqualsOverride),
+            new(Expected.EquatableContract.Content, Extensions.IsEquatable),
+            new(Expected.EquatableImplementation.Content, Extensions.HasEquatable),
+            new(Expected.GetHashCode.Content, Extensions.HasGetHashCodeOverride),
+            new(Expected.Inequality.Content, Extensions.HasInequalityOperator),
+            new(Expected.ToString.Content, Extensions.HasToStringOverride),
+        ],
+        nameof(ImmutableArrayProperty));
+}

--- a/src/Valuify/Model/Property.cs
+++ b/src/Valuify/Model/Property.cs
@@ -10,6 +10,14 @@ internal sealed class Property
     : Value<Property>
 {
     /// <summary>
+    /// Gets or sets a value indicating whether or not the type associated with the property is <see cref="System.Collections.Immutable.ImmutableArray{T}"/>.
+    /// </summary>
+    /// <value>
+    /// The value indicating whether or not the type associated with the property is <see cref="System.Collections.Immutable.ImmutableArray{T}"/>.
+    /// </value>
+    public bool IsImmutableArray { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether or not the property is marked as ignored.
     /// </summary>
     /// <value>
@@ -53,6 +61,7 @@ internal sealed class Property
     protected override IEnumerable<object> GetProperties()
     {
         yield return IsEquatable;
+        yield return IsImmutableArray;
         yield return IsIgnored;
         yield return IsSequence;
         yield return Name;

--- a/src/Valuify/Semantics/INamedTypeSymbolExtensions.GetAllProperties.cs
+++ b/src/Valuify/Semantics/INamedTypeSymbolExtensions.GetAllProperties.cs
@@ -21,11 +21,6 @@ internal static partial class INamedTypeSymbolExtensions
             return type.SpecialType != SpecialType.System_String && (type is IArrayTypeSymbol || type.AllInterfaces.Any(IsEnumerable));
         }
 
-        bool IsEquatable(ITypeSymbol type)
-        {
-            return type is INamedTypeSymbol namedType && namedType.IsEquatable(compilation);
-        }
-
         INamedTypeSymbol? current = @class;
 
         do
@@ -40,7 +35,8 @@ internal static partial class INamedTypeSymbolExtensions
             {
                 yield return new Property
                 {
-                    IsEquatable = IsEquatable(property.Type),
+                    IsEquatable = property.Type is INamedTypeSymbol namedType && namedType.IsEquatable(compilation),
+                    IsImmutableArray = property.Type.IsImmutableArray(compilation),
                     IsIgnored = property.HasIgnore(),
                     IsSequence = IsSequence(property.Type),
                     Name = property.Name,

--- a/src/Valuify/Semantics/INamedTypeSymbolExtensions.IsImmutableArray.cs
+++ b/src/Valuify/Semantics/INamedTypeSymbolExtensions.IsImmutableArray.cs
@@ -1,0 +1,35 @@
+﻿namespace Valuify.Semantics;
+
+using Microsoft.CodeAnalysis;
+
+/// <summary>
+/// Provides extensions relating to <see cref="INamedTypeSymbol"/>.
+/// </summary>
+internal static partial class INamedTypeSymbolExtensions
+{
+    private const string ImmutableArrayTypeName = "System.Collections.Immutable.ImmutableArray`1";
+
+    /// <summary>
+    /// Determines whether or not the <paramref name="type"/> is an <see cref="System.Collections.Immutable.ImmutableArray{T}"/>.
+    /// </summary>
+    /// <param name="type">
+    /// The symbol for the type to be checked.
+    /// </param>
+    /// <param name="compilation">
+    /// The <see cref="Compilation"/> used to source the symbol for <see cref="System.Collections.Immutable.ImmutableArray{T}"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the <paramref name="type"/> is an <see cref="System.Collections.Immutable.ImmutableArray{T}"/>, otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool IsImmutableArray(this ITypeSymbol type, Compilation compilation)
+    {
+        INamedTypeSymbol? immutableArray = compilation.GetTypeByMetadataName(ImmutableArrayTypeName);
+
+        if (immutableArray is null || type is not INamedTypeSymbol namedType)
+        {
+            return false;
+        }
+
+        return namedType.ConstructedFrom.Equals(immutableArray, SymbolEqualityComparer.Default);
+    }
+}

--- a/src/Valuify/Strategies/EquatableStrategy.cs
+++ b/src/Valuify/Strategies/EquatableStrategy.cs
@@ -74,8 +74,13 @@ internal sealed class EquatableStrategy
 
     private static string GetComparer(Property property)
     {
-        return property.IsSequence && !property.IsEquatable
+        return ShouldUseSequenceComparer(property)
             ? $"global::Valuify.Internal.SequenceEqualityComparer"
             : $"global::System.Collections.Generic.EqualityComparer<{property.Type}>";
+    }
+
+    private static bool ShouldUseSequenceComparer(Property property)
+    {
+        return property.IsSequence && (!property.IsEquatable || property.IsImmutableArray);
     }
 }


### PR DESCRIPTION
### Motivation
- Treat `System.Collections.Immutable.ImmutableArray<T>` as a sequence that requires sequence-based equality even when it may be `IEquatable<T>` to ensure generated equality uses the proper comparer.
- Capture and persist `IsImmutableArray` on `Property` so generation strategies can make correct decisions for immutable array properties.
- Add test coverage and expected generation snippets for types exposing `ImmutableArray<T>` properties.

### Description
- Added `Property.IsImmutableArray` to the model and included it in `GetProperties()` so it participates in value comparisons.
- Added `INamedTypeSymbolExtensions.IsImmutableArray` to detect `System.Collections.Immutable.ImmutableArray<T>` via `Compilation.GetTypeByMetadataName` and used it when building `Property` instances in `GetAllProperties()`.
- Updated `EquatableStrategy` to centralize selection logic in `ShouldUseSequenceComparer(Property)` and to treat immutable arrays as sequences that must use `global::Valuify.Internal.SequenceEqualityComparer` even if the element type is equatable.
- Added snippet, expected output, and test declarations for `ImmutableArrayProperty`, and added unit tests `GivenADifferentIsImmutableArrayThenTheyAreNotDeemedEqual` to both `WhenEqualityIsChecked` and `WhenInequalityIsChecked` test classes.

### Testing
- Ran the unit test suite with `dotnet test` and the tests completed successfully.
- New tests `WhenEqualityIsChecked.GivenADifferentIsImmutableArrayThenTheyAreNotDeemedEqual` and `WhenInequalityIsChecked.GivenADifferentIsImmutableArrayThenTheyAreNotDeemedEqual` were executed and passed as part of the test run.
- Snippet generation/validation tests for `ImmutableArrayProperty` were executed as part of the test suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6758fa128832f90bae9f80715f1a5)