### PR TITLE
Treat [Valuify]-annotated types as Equatable in current assembly and add AnnotatedEquatable tests

### DIFF
--- a/src/Valuify.Tests/Snippets/Declarations/AnnotatedEquatable.Declarations.cs
+++ b/src/Valuify.Tests/Snippets/Declarations/AnnotatedEquatable.Declarations.cs
@@ -1,0 +1,36 @@
+﻿namespace Valuify.Snippets.Declarations;
+
+using Microsoft.CodeAnalysis.CSharp;
+
+internal static partial class AnnotatedEquatable
+{
+    public static class Declarations
+    {
+        public static readonly Content CSharp9Body = new(
+            """
+                {
+                    public AnnotatedEquatableCollection Values { get; init; }
+                }
+            """,
+            LanguageVersion.CSharp9);
+
+        public static readonly Content Main = new(
+            """
+            namespace Valuify.Classes.Testing
+            {
+                using System.Collections.Generic;
+
+                [Valuify]
+                public sealed class AnnotatedEquatableCollection
+                    : List<int>
+                {
+                }
+
+                [Valuify]
+                public sealed partial class AnnotatedEquatable
+            __BODY__
+            }
+            """,
+            LanguageVersion.CSharp2);
+    }
+}

--- a/src/Valuify.Tests/Snippets/Declarations/AnnotatedEquatable.Expected.cs
+++ b/src/Valuify.Tests/Snippets/Declarations/AnnotatedEquatable.Expected.cs
@@ -1,0 +1,213 @@
+﻿namespace Valuify.Snippets.Declarations;
+
+internal static partial class AnnotatedEquatable
+{
+    public static class Expected
+    {
+        public static readonly Generated Equality = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Generic;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class AnnotatedEquatable
+                    {
+                        public static bool operator ==(AnnotatedEquatable left, AnnotatedEquatable right)
+                        {
+                            if (ReferenceEquals(left, right))
+                            {
+                                return true;
+                            }
+                
+                            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
+                            {
+                                return false;
+                            }
+                
+                            return left.Equals(right);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasEqualityOperator,
+            "Valuify.Classes.Testing.AnnotatedEquatable.Equality");
+
+        public static new readonly Generated Equals = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Generic;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class AnnotatedEquatable
+                    {
+                        public override bool Equals(object other)
+                        {
+                            return Equals(other as AnnotatedEquatable);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasEqualsOverride,
+            "Valuify.Classes.Testing.AnnotatedEquatable.Equals");
+
+        public static readonly Generated EquatableContract = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Generic;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class AnnotatedEquatable
+                        : IEquatable<AnnotatedEquatable>
+                    {
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.IsEquatable,
+            "Valuify.Classes.Testing.AnnotatedEquatable.IEquatable");
+
+        public static readonly Generated EquatableImplementation = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Generic;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class AnnotatedEquatable
+                    {
+                        public bool Equals(AnnotatedEquatable other)
+                        {
+                            if (ReferenceEquals(this, other))
+                            {
+                                return true;
+                            }
+                
+                            if (ReferenceEquals(other, null))
+                            {
+                                return false;
+                            }
+                
+                            return global::System.Collections.Generic.EqualityComparer<global::Valuify.Classes.Testing.AnnotatedEquatableCollection>.Default.Equals(Values, other.Values);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasEquatable,
+            "Valuify.Classes.Testing.AnnotatedEquatable.IEquatable.Equals");
+
+        public static new readonly Generated GetHashCode = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Generic;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+        
+                    partial class AnnotatedEquatable
+                    {
+                        public override int GetHashCode()
+                        {
+                            return global::Valuify.Internal.HashCode.Combine(Values);
+                        }
+                    }
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasGetHashCodeOverride,
+            "Valuify.Classes.Testing.AnnotatedEquatable.GetHashCode");
+
+        public static readonly Generated Inequality = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Generic;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class AnnotatedEquatable
+                    {
+                        public static bool operator !=(AnnotatedEquatable left, AnnotatedEquatable right)
+                        {
+                            return !(left == right);
+                        }
+                    }
+        
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasInequalityOperator,
+            "Valuify.Classes.Testing.AnnotatedEquatable.Inequality");
+
+        public static new readonly Generated ToString = new(
+            """
+                namespace Valuify.Classes.Testing
+                {
+                    using System;
+                    using System.Collections.Generic;
+
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable disable
+                    #endif
+
+                    partial class AnnotatedEquatable
+                    {
+                        public override string ToString()
+                        {
+                            return string.Format("AnnotatedEquatable {{ Values = {0} }}", Values);
+                        }
+                    }
+        
+                    #if NET5_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    #nullable restore
+                    #endif
+                }
+                """,
+            Extensions.HasToStringOverride,
+            "Valuify.Classes.Testing.AnnotatedEquatable.ToString");
+    }
+}

--- a/src/Valuify.Tests/Snippets/Declarations/AnnotatedEquatable.cs
+++ b/src/Valuify.Tests/Snippets/Declarations/AnnotatedEquatable.cs
@@ -1,0 +1,29 @@
+﻿namespace Valuify.Snippets.Declarations;
+
+internal static partial class AnnotatedEquatable
+{
+    public static readonly Snippets Declaration = new(
+        [
+            Declarations.CSharp9Body,
+        ],
+        Declarations.Main,
+        [
+            Expected.Equality,
+            Expected.Equals,
+            Expected.EquatableContract,
+            Expected.EquatableImplementation,
+            Expected.GetHashCode,
+            Expected.Inequality,
+            Expected.ToString,
+        ],
+        [
+            new(Expected.Equality.Content, Extensions.HasEqualityOperator),
+            new(Expected.Equals.Content, Extensions.HasEqualsOverride),
+            new(Expected.EquatableContract.Content, Extensions.IsEquatable),
+            new(Expected.EquatableImplementation.Content, Extensions.HasEquatable),
+            new(Expected.GetHashCode.Content, Extensions.HasGetHashCodeOverride),
+            new(Expected.Inequality.Content, Extensions.HasInequalityOperator),
+            new(Expected.ToString.Content, Extensions.HasToStringOverride),
+        ],
+        nameof(AnnotatedEquatable));
+}

--- a/src/Valuify/Semantics/INamedTypeSymbolExtensions.IsEquatable.cs
+++ b/src/Valuify/Semantics/INamedTypeSymbolExtensions.IsEquatable.cs
@@ -40,6 +40,13 @@ internal static partial class INamedTypeSymbolExtensions
                 && @interface.TypeArguments[0].Equals(@class, SymbolEqualityComparer.Default);
         }
 
-        return @class.AllInterfaces.Any(IsEquatable);
+        return @class.AllInterfaces.Any(IsEquatable)
+            || IsValuifiedInCurrentAssembly(@class, compilation);
+    }
+
+    private static bool IsValuifiedInCurrentAssembly(INamedTypeSymbol @class, Compilation compilation)
+    {
+        return SymbolEqualityComparer.Default.Equals(@class.ContainingAssembly, compilation.Assembly)
+            && @class.HasValuify();
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the generator treats classes annotated with `Valuify` in the current assembly as implementing `IEquatable<T>` so equality members are produced even if the interface isn't referenced by metadata.
- Add test snippets covering an annotated class that uses a collection property to validate produced equality, hashcode, operators, and `ToString` output.

### Description
- Extend `INamedTypeSymbolExtensions.IsEquatable` to return true for types that are `Valuify`-annotated in the current compilation by adding `IsValuifiedInCurrentAssembly` and including it in the equatability check. 
- Add test snippet declarations in `src/Valuify.Tests/Snippets/Declarations/AnnotatedEquatable.*` including `Declarations`, `Expected`, and `Declaration` that exercise generated equality operators, `Equals`, `GetHashCode`, `IEquatable<T>` implementation, inequality operator, and `ToString`.
- Wire the new snippets into the test expectations using existing `Extensions` flags to assert presence of generated members.

### Testing
- Ran the test suite for `Valuify.Tests` including the new `AnnotatedEquatable` snippets; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a160098c832fafb3bca2a8e34d44)